### PR TITLE
Translate 'childs' to the proper 'children'

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -102,7 +102,7 @@ module.exports = function parse(xml, options, callback) {
         if ( ! options.cdata || ! inPath()) {
             return;
         }
-        pointer.childs[pointer.childs.length - 1].push(chunk);
+        pointer.children[pointer.children.length - 1].push(chunk);
     };
 
     parser.onclosecdata = function() {

--- a/lib/xml.js
+++ b/lib/xml.js
@@ -11,7 +11,7 @@ var util = require('util'),
  * @constructor
  */
 var NodeSet = xml.NodeSet = function NodeSet(nodes) {
-    this.childs = (arguments.length === 1 && (Array.isArray(nodes))) ? nodes : Array.apply(Array, arguments);
+    this.children = (arguments.length === 1 && (Array.isArray(nodes))) ? nodes : Array.apply(Array, arguments);
 };
 
 /**
@@ -20,7 +20,7 @@ var NodeSet = xml.NodeSet = function NodeSet(nodes) {
  * @returns {Array}
  */
 NodeSet.prototype.toJSON = function() {
-    return this.childs;
+    return this.children;
 };
 
 /**
@@ -29,31 +29,31 @@ NodeSet.prototype.toJSON = function() {
  * @returns {String}
  */
 NodeSet.prototype.toString = function() {
-    return this.childs.toString();
+    return this.children.toString();
 };
 
 /**
  * Expose most of array instance methods to NodeSet instance,
- * mutators are not exposed to keep `childs` safe.
+ * mutators are not exposed to keep `children` safe.
  */
 [
     'join', 'indexOf', 'lastIndexOf', 'forEach', 'map', 'reduce',
     'reduceRight', 'filter', 'some', 'every', 'concat', 'slice'
 ].forEach(function(methodName) {
         NodeSet.prototype[methodName] = function() {
-            return Array.prototype[methodName].apply(this.childs, arguments);
+            return Array.prototype[methodName].apply(this.children, arguments);
         };
     });
 
 /**
  * Append node to node set.
- * This method is one and only mutator of the `childs`.
+ * This method is one and only mutator of the `children`.
  *
  * @param {Tag|Comment|String} node
  * @private
  */
 NodeSet.prototype.append = function(node) {
-    this.childs.push(node);
+    this.children.push(node);
     return this;
 };
 
@@ -61,7 +61,7 @@ NodeSet.prototype.append = function(node) {
  * @property {Number} length
  */
 NodeSet.prototype.__defineGetter__('length', function() {
-    return this.childs.length;
+    return this.children.length;
 });
 
 /**
@@ -79,7 +79,7 @@ NodeSet.prototype.get = function(expr) {
 NodeSet.prototype.explode = function() {
     return this.reduce(function(result, tag) {
         if (tag instanceof NodeSet) {
-            result.childs = result.childs.concat(tag.childs);
+            result.children = result.children.concat(tag.children);
         }
         return result;
     }, new NodeSet());
@@ -147,7 +147,7 @@ NodeSet.prototype.isAttr = function(name, value) {
  * @returns {Tag|Comment|String} node by `index` or `null` if `index` out of bounds
  */
 NodeSet.prototype.eq = function(index) {
-    return this.childs[index] || null;
+    return this.children[index] || null;
 };
 
 /**
@@ -185,8 +185,8 @@ util.inherits(Tag, NodeSet);
 /**
  * Custom Tag#toJSON()
  * * doesn't expose `parent` property to JSON;
- * * expose non-empty `attrs` and `childs` properties;
- * * if Tag has only one text child, expose it as `text` instead of `childs` array.
+ * * expose non-empty `attrs` and `children` properties;
+ * * if Tag has only one text child, expose it as `text` instead of `children` array.
  *
  * @returns {Object}
  */
@@ -197,10 +197,10 @@ Tag.prototype.toJSON = function() {
         jsonTag.attrs = this.attrs;
     }
 
-    if (this.length === 1 && typeof this.childs[0] === 'string') {
-        jsonTag.text = this.childs[0];
+    if (this.length === 1 && typeof this.children[0] === 'string') {
+        jsonTag.text = this.children[0];
     } else if (this.length > 0) {
-        jsonTag.childs = this.childs;
+        jsonTag.children = this.children;
     }
 
     return jsonTag;

--- a/test/data/partial.json
+++ b/test/data/partial.json
@@ -1,7 +1,7 @@
 [
     {
         "name" : "customer",
-        "childs" : [
+        "children" : [
             {
                 "name" : "name",
                 "text" : "Jimi Hendrix"

--- a/test/data/simple.json
+++ b/test/data/simple.json
@@ -5,13 +5,13 @@
             "revision" : "2134",
             "owner" : "Chief"
         },
-        "childs" : [
+        "children" : [
             {
                 "name" : "food",
                 "attrs" : {
                     "id" : "1"
                 },
-                "childs" : [
+                "children" : [
                     {
                         "name" : "name",
                         "text" : "Belgian Waffles"
@@ -39,7 +39,7 @@
                 "attrs" : {
                     "id" : "2"
                 },
-                "childs" : [
+                "children" : [
                     {
                         "name" : "name",
                         "text" : "Strawberry Belgian Waffles"
@@ -72,7 +72,7 @@
                 "attrs" : {
                     "id" : "3"
                 },
-                "childs" : [
+                "children" : [
                     {
                         "name" : "name",
                         "text" : "Berry-Berry Belgian Waffles"
@@ -99,7 +99,7 @@
                 "attrs" : {
                     "id" : "4"
                 },
-                "childs" : [
+                "children" : [
                     {
                         "name" : "name",
                         "text" : "French Toast"
@@ -126,7 +126,7 @@
                 "attrs" : {
                     "id" : "5"
                 },
-                "childs" : [
+                "children" : [
                     {
                         "name" : "name",
                         "text" : "Homestyle Breakfast"
@@ -148,7 +148,7 @@
                     },
                     {
                         "name" : "customer",
-                        "childs" : [
+                        "children" : [
                             {
                                 "name" : "name",
                                 "text" : "Jimi Hendrix"

--- a/test/nodeset.js
+++ b/test/nodeset.js
@@ -12,17 +12,17 @@ test['NodeSet (constructor)'] = function(beforeExit, assert) {
 
     assert.strictEqual(typeof nset, 'object');
     assert.ok(nset instanceof NodeSet);
-    assert.deepEqual(nset.childs, ARRAY);
+    assert.deepEqual(nset.children, ARRAY);
 };
 
 test['NodeSet (append)'] = function(beforeExit, assert) {
     var nset = new NodeSet(),
         TEXT = 'hello';
 
-    assert.strictEqual(nset.childs.length, 0);
+    assert.strictEqual(nset.children.length, 0);
     nset.append(TEXT);
-    assert.strictEqual(nset.childs.length, 1);
-    assert.strictEqual(nset.childs[0], TEXT);
+    assert.strictEqual(nset.children.length, 1);
+    assert.strictEqual(nset.children[0], TEXT);
 };
 
 test['NodeSet (length)'] = function(beforeExit, assert) {
@@ -55,13 +55,13 @@ test['NodeSet (text)'] = function(beforeExit, assert) {
 test['NodeSet (toJSON)'] = function(beforeExit, assert) {
     var nset = new NodeSet('Hello,', 'World!');
 
-    assert.strictEqual(JSON.stringify(nset), JSON.stringify(nset.childs));
+    assert.strictEqual(JSON.stringify(nset), JSON.stringify(nset.children));
 };
 
 test['NodeSet (toString)'] = function(beforeExit, assert) {
     var nset = new NodeSet('Hello,', 'World!');
 
-    assert.strictEqual(nset.toString(), nset.childs.toString());
+    assert.strictEqual(nset.toString(), nset.children.toString());
 };
 
 test['NodeSet (get)'] = function(beforeExit, assert) {
@@ -80,14 +80,14 @@ test['NodeSet (get)'] = function(beforeExit, assert) {
 
     assert.strictEqual(nsetAll.length, nset.length);
     nsetAll.forEach(function(node, idx) {
-        assert.strictEqual(node, nset.childs[idx]);
+        assert.strictEqual(node, nset.children[idx]);
     });
     assert.strictEqual(nsetTags.length, 2);
     nsetTags.forEach(function(tag) {
             assert.ok(tag instanceof Tag);
         });
     assert.strictEqual(nsetRootTag.length, 1);
-    assert.strictEqual(nsetRootTag.childs[0].name, 'root');
+    assert.strictEqual(nsetRootTag.children[0].name, 'root');
     assert.strictEqual(nsetText.length, 2);
     assert.strictEqual(nsetText.join(' '), 'Hello, World!');
     nsetText.forEach(function(text) {
@@ -165,7 +165,7 @@ test['NodeSet (explode)'] = function(beforeExit, assert) {
     assert.strictEqual(nsetExploded.length, tag.length);
 
     nsetExploded.forEach(function(child, idx) {
-        assert.strictEqual(child, tag.childs[idx]);
+        assert.strictEqual(child, tag.children[idx]);
     });
 };
 
@@ -181,8 +181,8 @@ test['NodeSet (hasAttr)'] = function(beforeExit, assert) {
     assert.strictEqual(nsetOne.length, 1);
     assert.strictEqual(nsetTwo.length, 1);
 
-    assert.strictEqual(nsetOne.childs[0].name, TAG_ONE);
-    assert.strictEqual(nsetTwo.childs[0].name, TAG_TWO);
+    assert.strictEqual(nsetOne.children[0].name, TAG_ONE);
+    assert.strictEqual(nsetTwo.children[0].name, TAG_TWO);
 };
 
 test['NodeSet (isAttr)'] = function(beforeExit, assert) {
@@ -197,8 +197,8 @@ test['NodeSet (isAttr)'] = function(beforeExit, assert) {
     assert.strictEqual(nsetOne.length, 1);
     assert.strictEqual(nsetTwo.length, 1);
 
-    assert.strictEqual(nsetOne.childs[0].name, TAG_ONE);
-    assert.strictEqual(nsetTwo.childs[0].name, TAG_TWO);
+    assert.strictEqual(nsetOne.children[0].name, TAG_ONE);
+    assert.strictEqual(nsetTwo.children[0].name, TAG_TWO);
 };
 
 test['NodeSet (eq)'] = function(beforeExit, assert) {


### PR DESCRIPTION
That'd be nice and simple but unfortunately 'childs' is not valid in english :P

This change aims to correct all the references to the proper word, 'children'. I just made a whole-directory search-and-replace. Tests pass.
